### PR TITLE
2 fixes for x86_64 and ARM platforms

### DIFF
--- a/ECCK.c
+++ b/ECCK.c
@@ -1304,9 +1304,9 @@ void partial_mod(uint32 *k, uint32 *r0, uint32 *r1, uint32 curve_id)
 /*******************************************************************************************
  Compute a width-5 TNAF of an element in Z[t]
  ********************************************************************************************/
-void TNAF5_expansion(uint32 *r0, uint32 *r1, char *u, uint32 curve_id)
+void TNAF5_expansion(uint32 *r0, uint32 *r1, signed char *u, uint32 curve_id)
 {	
-	char t;
+	signed char t;
 	uint32 i, j, r, c, v, Num;
 	uint64 T;
 	uint32 s0[4], s1[4], s2[4];
@@ -1365,8 +1365,8 @@ void TNAF5_expansion(uint32 *r0, uint32 *r1, char *u, uint32 curve_id)
 				//get the lowest 5 bits of r0+tw*r1 
 				r = r & 0x1f;
 
-				if(r >= 0 && r <= 16) t = (char)r;
-				else t = (char)r - 32;
+				if(r >= 0 && r <= 16) t = (signed char)r;
+				else t = (signed char)r - 32;
 
 				*(u + i) = t;
 			}
@@ -1386,8 +1386,8 @@ void TNAF5_expansion(uint32 *r0, uint32 *r1, char *u, uint32 curve_id)
 				//get the lowest 5 bits of r0+tw*r1 
 				r = r & 0x1f;
 
-				if(r >= 0 && r <= 16) t = -(char)r;
-				else t = 32 - (char)r;
+				if(r >= 0 && r <= 16) t = -(signed char)r;
+				else t = 32 - (signed char)r;
 
 				*(u + i) = t;
 			}
@@ -1407,8 +1407,8 @@ void TNAF5_expansion(uint32 *r0, uint32 *r1, char *u, uint32 curve_id)
 				//take out the lowest 5 bits of r0+(32+tw)*|r1| 
 				r = r & 0x1f;
 
-				if(r >= 0 && r <= 16) t = (char)r;
-				else t = (char)r - 32;
+				if(r >= 0 && r <= 16) t = (signed char)r;
+				else t = (signed char)r - 32;
 
 				*(u + i) = t;
 			}
@@ -1428,8 +1428,8 @@ void TNAF5_expansion(uint32 *r0, uint32 *r1, char *u, uint32 curve_id)
 				//take out the lowest 5 bits of -(|r0|+(32+tw)*r1) 
 				r = r & 0x1f;
 
-				if(r >= 0 && r <= 16) t = -(char)r;
-				else t = 32 - (char)r;
+				if(r >= 0 && r <= 16) t = -(signed char)r;
+				else t = 32 - (signed char)r;
 
 				*(u + i) = t;
 			}
@@ -1765,7 +1765,7 @@ void TNAF5_expansion(uint32 *r0, uint32 *r1, char *u, uint32 curve_id)
   *************************************************************************************************/
   void TNAF5_fixed_scalarmul(uint32 *k, ec_point_aff *Q, uint32 curve_id)
   {
-	  char a[236] = {0x0};
+	  signed char a[236] = {0x0};
 	  uint32 i, Num, BitLen;
 	  uint32 lamda0[5];
 	  uint32 lamda1[5];
@@ -1849,7 +1849,7 @@ void TNAF5_expansion(uint32 *r0, uint32 *r1, char *u, uint32 curve_id)
   *************************************************************************************************/
   void TNAF5_random_scalarmul(uint32 *k, ec_point_aff *P, ec_point_aff *Q, uint32 curve_id)
   {
-	  char a[236] = {0x0};
+	  signed char a[236] = {0x0};
 	  uint32 i, Num, BitLen;
 	  uint32 lamda0[5];
 	  uint32 lamda1[5];

--- a/ECCK.h
+++ b/ECCK.h
@@ -85,7 +85,7 @@ void partial_mod(uint32 *k, uint32 *r0, uint32 *r1, uint32 curve_id);
 /**
  * Width-5 TNAF expansion 
  */
-void TNAF5_expansion(uint32 *r0, uint32 *r1, char *u, uint32 curve_id);
+void TNAF5_expansion(uint32 *r0, uint32 *r1, signed char *u, uint32 curve_id);
 
 /**
  * Scalar multiplication with the width-5 TNAF (fixed point)

--- a/OpenECC.h
+++ b/OpenECC.h
@@ -29,6 +29,9 @@
 #ifndef __OpenECC_H__
 #define __OpenECC_H__
 
+
+#include <stdint.h>
+
 /**
  * Support for both ZigBee Smart Energy 1.x and 1.2
  * Use curve sect163k1 for ZigBee Smart Energy 1.x
@@ -45,11 +48,11 @@
 /**
  * Define data type
  */
-typedef unsigned char uint8;          /* Unsigned 8  bit value */
-typedef unsigned short uint16;        /* Unsigned 16 bit value */
-typedef unsigned long uint32;         /* Unsigned 32 bit value */
-typedef unsigned long long uint64;    /* Unsigned 64 bit value */
-typedef long int sint32;              /* Signed 32 bit value */
+typedef uint8_t uint8;          /* Unsigned 8  bit value */
+typedef uint16_t uint16;        /* Unsigned 16 bit value */
+typedef uint32_t uint32;         /* Unsigned 32 bit value */
+typedef uint64_t uint64;    /* Unsigned 64 bit value */
+typedef int32_t sint32;              /* Signed 32 bit value */
 
 /**
  * Define macros


### PR DESCRIPTION
- using stdint.h, because of int and long types are arch specific
- using signed char explicitly instead of char because of C standard does not define char type signedness (see ISO 9899:1999, section "6.2.5 Types"). More over ARM gcc uses unsigned char by default
